### PR TITLE
Add Renku session link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Quick Test](https://github.com/MannLabs/alphapept/workflows/Quick%20Test/badge.svg)
 ![Performance test](https://github.com/MannLabs/alphapept/workflows/Performance%20test/badge.svg)
 ![Windows Installer](https://github.com/MannLabs/alphapept/workflows/Windows%20Installer/badge.svg)
-[![launch - renku](https://renkulab.io/renku-badge.svg)](https://renkulab.io/projects/renku-stories/alphapept-gui-streamlit/sessions/new?autostart=1)
+[![launch - renku](https://renkulab.io/renku-badge.svg)](https://renkulab.io/projects/renku-stories/alphapept-gui-streamlit)
 
 [![DOI:10.1101/2021.07.23.453379](http://img.shields.io/badge/DOI-10.1101/2021.07.23.453379-B31B1B.svg)](https://www.biorxiv.org/content/10.1101/2021.07.23.453379v1)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Quick Test](https://github.com/MannLabs/alphapept/workflows/Quick%20Test/badge.svg)
 ![Performance test](https://github.com/MannLabs/alphapept/workflows/Performance%20test/badge.svg)
 ![Windows Installer](https://github.com/MannLabs/alphapept/workflows/Windows%20Installer/badge.svg)
+[![launch - renku](https://renkulab.io/renku-badge.svg)](https://renkulab.io/projects/renku-stories/alphapept-gui-streamlit/sessions/new?autostart=1)
 
 [![DOI:10.1101/2021.07.23.453379](http://img.shields.io/badge/DOI-10.1101/2021.07.23.453379-B31B1B.svg)](https://www.biorxiv.org/content/10.1101/2021.07.23.453379v1)
 


### PR DESCRIPTION
This PR proposes to add a "launch on [renku](https://renkulab.io/)" badge to the README.

Like binder, renku provides interactive jupyterlab sessions for user to try notebooks and code examples.
In addition, renku sessions are tied to a gitlab repository, which logged in users can fork to modify the code and save their changes.

The badge starts a session from a [renku gitlab repository](https://renkulab.io/projects/renku-stories/alphapept-gui-streamlit). When a session is started, it builds a docker image with Alphapept installed from the repository and gives you access to the alphapept streamlit interface.

For this particular example, I have setup a gitlab repository including alphapept as a dependency (in `requirements.txt`). I also included [a dataset](https://renkulab.io/projects/renku-stories/alphapept-gui-streamlit/datasets/test-raw-ms-data/) with some demo raw MS files ([imported from Zenodo](https://zenodo.org/record/4307762)), as well as Alphapept results from processing these files. In the session, these files are available in the `data/` folder. Users can then experiment with Alphapept, either by processing the raw files, or analyzing the results directly.